### PR TITLE
run-ecs-task: use entry point instead of command to run tasks

### DIFF
--- a/run-ecs-task/index.js
+++ b/run-ecs-task/index.js
@@ -55,7 +55,7 @@ async function run() {
           containerOverrides: [
             {
               name: containerName,
-              command: ["sh", "-c", command],
+              entryPoint: ["sh", "-c", command],
             },
           ],
         },


### PR DESCRIPTION
Motivation: entry point overrides cmd or entry point, but not vice versa. If task has an entry point defined, this becomes important.