### PR TITLE
Revert "run-ecs-task: use entry point instead of command to run tasks"

### DIFF
--- a/run-ecs-task/index.js
+++ b/run-ecs-task/index.js
@@ -55,7 +55,7 @@ async function run() {
           containerOverrides: [
             {
               name: containerName,
-              entryPoint: ["sh", "-c", command],
+              command: ["sh", "-c", command],
             },
           ],
         },


### PR DESCRIPTION
Reverts railsware/github-actions#29

Unfortunately this doesn't work at all, you cannot override the entrypoint.