### PR TITLE
Change show-raw-output behaviour

### DIFF
--- a/run-ecs-task/action.yml
+++ b/run-ecs-task/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: "Task command"
     required: true
   show-raw-output:
-    description: "Wait for task to complete and display output from task"
+    description: "Display task logs"
     default: false
 
 outputs:

--- a/run-ecs-task/action.yml
+++ b/run-ecs-task/action.yml
@@ -16,6 +16,10 @@ inputs:
   command:
     description: "Task command"
     required: true
+  wait-for-completion:
+    description: "Whether to wait for the task execution to complete"
+    required: false
+    default: true
   show-raw-output:
     description: "Display task logs"
     default: false

--- a/run-ecs-task/index.js
+++ b/run-ecs-task/index.js
@@ -74,11 +74,11 @@ async function run() {
     console.log(`Task started. Track it online at ${outputURL}`);
 
     core.setOutput("url", outputURL);
-    if (showRawOutput) {
 
     await waitTaskToComplete(ecs, cluster, taskID)
     console.log(`Task completed`);
 
+    if (showRawOutput === "true") {
       const logConfig = taskDefinition.containerDefinitions[0].logConfiguration
       const logs = await readTaskLogs(logConfig, containerName, taskID)
 

--- a/run-ecs-task/index.js
+++ b/run-ecs-task/index.js
@@ -76,8 +76,8 @@ async function run() {
     core.setOutput("url", outputURL);
     if (showRawOutput) {
 
-      await waitTaskToComplete(ecs, cluster, taskID)
-      console.log(`Task completed`);
+    await waitTaskToComplete(ecs, cluster, taskID)
+    console.log(`Task completed`);
 
       const logConfig = taskDefinition.containerDefinitions[0].logConfiguration
       const logs = await readTaskLogs(logConfig, containerName, taskID)

--- a/run-ecs-task/index.js
+++ b/run-ecs-task/index.js
@@ -10,6 +10,7 @@ async function run() {
     const definedContainerName = core.getInput("container", { required: false });
     const command = core.getInput("command", { required: true });
     const givenTaskDefinition = core.getInput("task-definition", { required: false });
+    const waitForCompletion = core.getInput("wait-for-completion", { required: false });
     const showRawOutput = core.getInput("show-raw-output", { required: false });
 
     const ecs = new AWS.ECS();
@@ -75,8 +76,12 @@ async function run() {
 
     core.setOutput("url", outputURL);
 
-    await waitTaskToComplete(ecs, cluster, taskID)
-    console.log(`Task completed`);
+    if (waitForCompletion === "true") {
+      await waitTaskToComplete(ecs, cluster, taskID)
+      console.log("Task completed");
+    } else {
+      console.log("The task is up and running but the action isn't going to wait for execution to complete");
+    }
 
     if (showRawOutput === "true") {
       const logConfig = taskDefinition.containerDefinitions[0].logConfiguration


### PR DESCRIPTION
Currently, the `showRawOutput` variable in the action is always `true` because it's a string variable with the possible values: `true` or `false`. A discussion about this behaviour in GitHub Actions can be found in [here](https://github.com/actions/runner/issues/1483). The current PR addresses this issue. 

Also, the `show-raw-output` input argument doesn't control the `waitTaskToComplete` function invocation. The function is always invoked. I think if there is a need to disable the function it has to be done with a separate flag.

Additionally, the PR introduces a new flag `wait-for-completion` which in turn controls whether the `waitTaskToComplete` function will be invoked or won't.