### PR TITLE
Add support for ECS tasks managed by CodeDeploy

### DIFF
--- a/run-ecs-task/index.js
+++ b/run-ecs-task/index.js
@@ -47,6 +47,10 @@ async function run() {
       }
     })()
 
+    const networkConfiguration = service.deployments[0] ? 
+      service.deployments[0].networkConfiguration : 
+      service.taskSets[0].networkConfiguration
+
     const taskResponse = await ecs
       .runTask({
         cluster,
@@ -60,7 +64,7 @@ async function run() {
             },
           ],
         },
-        networkConfiguration: service.deployments[0].networkConfiguration,
+        networkConfiguration
       })
       .promise();
 


### PR DESCRIPTION
### Motivation 
We want to execute task which is managed by CodeDelpy
- #issue Such tasks does not have `deployments[]`
  - so we are getting can read proerty`.networkConfiguration` of `undefined`
- #idea we can read `networkConfiguration` from `taskSets[]` instead

### Changes
- Optionally read `networkConfiguration` if no `deployments` listed in ECS details 