### PR TITLE
MT-5411: Running ecs task rely on task exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of GitHub actions used at Railsware
 ---
 
 ## running action on local machine
-- `yarn run_action name --param-1 value1 --param-2 value2 --param-3 value`
+- `yarn run_action --action name --param-1 value1 --param-2 value2 --param-3 value`
   - `name` action name to run
   - `param-x` - param like they specified in action.yml
 

--- a/run-ecs-task/__tests__/runEcsTask.test.js
+++ b/run-ecs-task/__tests__/runEcsTask.test.js
@@ -1,0 +1,253 @@
+const runEcsTask = require('../runEcsTask')
+
+describe('runEcsTask', () => {
+  const buildMock = (data) => (
+    jest.fn().mockReturnValue({
+      promise: () => Promise.resolve(data)
+    })
+  )
+  const buildEcsMock = ({
+                          describeServices = buildMock({
+                            services: [{
+                              taskDefinition: 'ServiceTaskDefinition',
+                              deployments: [{
+                                networkConfiguration: 'deployentNetworkConfiguration'
+                              }],
+                              taskSets: [{
+                                networkConfiguration: 'taskSetsNetworkConfiguration'
+                              }]
+                            }]
+                          }),
+                          describeTaskDefinition = buildMock({
+                            taskDefinition: {
+                              containerDefinitions: [{
+                                name: 'EcsContainerDefinition',
+                                logConfiguration: {
+                                  logDriver: 'awslogs',
+                                  options: {
+                                    'awslogs-group': 'MyLogGroup',
+                                    'awslogs-stream-prefix': 'MyPrefix'
+                                  }
+                                }
+                              }]
+                            }
+                          }),
+                          runTask = buildMock({
+                            tasks: [{
+                              taskArn: 'arn:aws:ecs:us-east-1:12345:task/qa-mailtrap/some-hash'
+                            }]
+                          }),
+                          describeTasks = buildMock({
+                            tasks: [{
+                              lastStatus: 'STOPPED',
+                              containers: [{
+                                name: 'EcsContainerDefinition',
+                                exitCode: 0
+                              }]
+                            }]
+                          })
+
+                        }) => ({
+    describeServices,
+    describeTaskDefinition,
+    runTask,
+    describeTasks
+  })
+
+  it('exits normally if task exits with 0 code', async () => {
+    const ecs = buildEcsMock({})
+
+    await runEcsTask({
+      ecs,
+      cluster: 'MyCluster',
+      serviceName: 'MyService',
+      definedContainerName: null,
+      command: 'echo "whatever"',
+      givenTaskDefinition: null,
+      waitForCompletion: 'true'
+    })
+
+    expect(ecs.describeServices.mock.calls.length).toEqual(1)
+    expect(ecs.describeServices.mock.calls[0]).toEqual([{
+      "cluster": "MyCluster",
+      "services": ["MyService"]
+    }])
+
+    expect(ecs.describeTaskDefinition.mock.calls.length).toEqual(1)
+    expect(ecs.describeTaskDefinition.mock.calls[0]).toEqual([{"taskDefinition": "ServiceTaskDefinition"}])
+
+    expect(ecs.runTask.mock.calls.length).toEqual(1)
+    expect(ecs.runTask.mock.calls[0]).toEqual([{
+      "cluster": "MyCluster",
+      "launchType": "FARGATE",
+      "networkConfiguration": "deployentNetworkConfiguration",
+      "overrides": {
+        "containerOverrides": [{
+          "command": ["sh", "-c", "echo \"whatever\""],
+          "name": "EcsContainerDefinition"
+        }]
+      },
+      "taskDefinition": undefined
+    }])
+
+    expect(ecs.describeTasks.mock.calls.length).toEqual(1)
+    expect(ecs.describeTasks.mock.calls[0]).toEqual([{"cluster": "MyCluster", "tasks": ["some-hash"]}])
+  })
+
+  it('throws if task exits with 0 code', async () => {
+    const ecs = buildEcsMock({
+        describeTasks: buildMock({
+          tasks: [{
+            lastStatus: 'STOPPED',
+            containers: [{
+              name: 'EcsContainerDefinition',
+              exitCode: 123
+            }]
+          }]
+        })
+      }
+    )
+
+    await expect(runEcsTask({
+      ecs,
+      cluster: 'MyCluster',
+      serviceName: 'MyService',
+      definedContainerName: null,
+      command: 'echo "whatever"',
+      givenTaskDefinition: null,
+      waitForCompletion: 'true'
+    })).rejects.toThrow('Task exited abnormally. Exit code: 123')
+  })
+
+  it('calls given task definition', async () => {
+    const ecs = buildEcsMock({})
+
+    await runEcsTask({
+      ecs,
+      cluster: 'MyCluster',
+      serviceName: 'MyService',
+      definedContainerName: null,
+      command: 'echo "whatever"',
+      givenTaskDefinition: 'GivenTaskDefinition',
+      waitForCompletion: 'true'
+    })
+
+    expect(ecs.describeTaskDefinition.mock.calls.length).toEqual(1)
+    expect(ecs.describeTaskDefinition.mock.calls[0]).toEqual([{"taskDefinition": "GivenTaskDefinition"}])
+  })
+
+  it('calls given container', async () => {
+    const ecs = buildEcsMock({
+      describeTaskDefinition: buildMock({
+        taskDefinition: {
+          containerDefinitions: [{
+            name: 'EcsContainerDefinition',
+            logConfiguration: {
+              logDriver: 'awslogs',
+              options: {
+                'awslogs-group': 'MyLogGroup',
+                'awslogs-stream-prefix': 'MyPrefix'
+              }
+            }
+          }, {
+            name: 'definedContainerName',
+            logConfiguration: {
+              logDriver: 'awslogs',
+              options: {
+                'awslogs-group': 'DefinedLogGroup',
+                'awslogs-stream-prefix': 'DefinedPrefix'
+              }
+            }
+          }]
+        }
+      }),
+      describeTasks: buildMock({
+        tasks: [{
+          lastStatus: 'STOPPED',
+          containers: [{
+            name: 'EcsContainerDefinition',
+            exitCode: 0
+          }, {
+            name: 'definedContainerName',
+            exitCode: 0
+          }]
+        }]
+      })
+
+    })
+
+    await runEcsTask({
+      ecs,
+      cluster: 'MyCluster',
+      serviceName: 'MyService',
+      definedContainerName: 'definedContainerName',
+      command: 'echo "whatever"',
+      givenTaskDefinition: null,
+      waitForCompletion: 'true'
+    })
+
+    expect(ecs.runTask.mock.calls.length).toEqual(1)
+    expect(ecs.runTask.mock.calls[0]).toEqual([{
+      "cluster": "MyCluster",
+      "launchType": "FARGATE",
+      "networkConfiguration": "deployentNetworkConfiguration",
+      "overrides": {
+        "containerOverrides": [{
+          "command": ["sh", "-c", "echo \"whatever\""],
+          "name": "definedContainerName"
+        }]
+      },
+      "taskDefinition": undefined
+    }])
+  })
+
+  it('raises if there are multiple containers defined', async () => {
+    const ecs = buildEcsMock({
+      describeTaskDefinition: buildMock({
+        taskDefinition: {
+          containerDefinitions: [{
+            name: 'EcsContainerDefinition',
+            logConfiguration: {
+              logDriver: 'awslogs',
+              options: {
+                'awslogs-group': 'MyLogGroup',
+                'awslogs-stream-prefix': 'MyPrefix'
+              }
+            }
+          }, {
+            name: 'definedContainerName',
+            logConfiguration: {
+              logDriver: 'awslogs',
+              options: {
+                'awslogs-group': 'DefinedLogGroup',
+                'awslogs-stream-prefix': 'DefinedPrefix'
+              }
+            }
+          }]
+        }
+      }),
+      describeTasks: buildMock({
+        tasks: [{
+          lastStatus: 'STOPPED',
+          containers: [{
+            name: 'EcsContainerDefinition',
+            exitCode: 0
+          }, {
+            name: 'definedContainerName',
+            exitCode: 0
+          }]
+        }]
+      })
+    })
+
+    await expect(runEcsTask({
+      ecs,
+      cluster: 'MyCluster',
+      serviceName: 'MyService',
+      definedContainerName: null,
+      command: 'echo "whatever"',
+      givenTaskDefinition: null,
+      waitForCompletion: 'true'
+    })).rejects.toThrow('Running in tasks with more than one container is not yet supported')
+  })
+})

--- a/run-ecs-task/package.json
+++ b/run-ecs-task/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "prepublish": "node_modules/.bin/ncc build index.js -m -o dist",
-    "test": "echo 'No tests for fetch-task-definition'"
+    "test": "TZ=utc jest"
   }
 }

--- a/run-ecs-task/runEcsTask.js
+++ b/run-ecs-task/runEcsTask.js
@@ -1,0 +1,91 @@
+const core = require("@actions/core");
+const readTaskLogs = require("./readTaskLogs")
+const waitTaskToComplete = require("./waitTaskToComplete")
+
+async function runEcsTask({ ecs, cluster, serviceName, definedContainerName, command, givenTaskDefinition, waitForCompletion, showRawOutput }) {
+  const servicesResponse = await ecs
+    .describeServices({ cluster, services: [serviceName] })
+    .promise();
+
+  if (!servicesResponse.services || servicesResponse.services.length === 0) {
+    throw new Error("no such service");
+  }
+
+  const service = servicesResponse.services[0];
+
+  const {taskDefinition} = await ecs
+    .describeTaskDefinition({
+      taskDefinition: givenTaskDefinition || service.taskDefinition,
+    })
+    .promise();
+
+  const containerName = (() => {
+    if (definedContainerName) {
+      return definedContainerName;
+    } else {
+      if (taskDefinition.containerDefinitions.length != 1) {
+        throw new Error(
+          "Running in tasks with more than one container is not yet supported"
+        );
+      }
+
+      return taskDefinition.containerDefinitions[0].name;
+    }
+  })()
+
+  const networkConfiguration = service.deployments[0] ?
+    service.deployments[0].networkConfiguration :
+    service.taskSets[0].networkConfiguration
+
+  const taskResponse = await ecs
+    .runTask({
+      cluster,
+      taskDefinition: taskDefinition.taskDefinitionArn,
+      launchType: "FARGATE",
+      overrides: {
+        containerOverrides: [
+          {
+            name: containerName,
+            command: ["sh", "-c", command],
+          },
+        ],
+      },
+      networkConfiguration
+    })
+    .promise();
+
+  const taskArn = taskResponse.tasks[0].taskArn;
+  const taskArnParts = taskArn.split(":");
+  const taskRegion = taskArnParts[3];
+  const idParts = taskArnParts[5].split("/");
+  const taskID = idParts[idParts.length - 1];
+
+  const outputURL = `https://${taskRegion}.console.aws.amazon.com/ecs/home?region=${taskRegion}#/clusters/${cluster}/tasks/${taskID}/details`;
+
+  console.log(`Task started. Track it online at ${outputURL}`);
+
+  core.setOutput("url", outputURL);
+
+  if (waitForCompletion === "true") {
+    const task = await waitTaskToComplete(ecs, cluster, taskID)
+    console.log("Task completed")
+
+    if (showRawOutput === "true") {
+      const logConfig = taskDefinition.containerDefinitions[0].logConfiguration
+      const logs = await readTaskLogs(logConfig, containerName, taskID)
+
+      const prettyOutput = JSON.stringify(logs, null, 2)
+      console.log(`Task output %o`, prettyOutput);
+      core.setOutput("raw_output", logs);
+    }
+
+    const container = task.containers.find(({name}) => name === containerName);
+    if (container && container.exitCode !== 0) {
+      throw new Error(`Task exited abnormally. Exit code: ${container.exitCode}`)
+    }
+  } else {
+    console.log("The task is up and running but the action isn't going to wait for execution to complete");
+  }
+}
+
+module.exports = runEcsTask;

--- a/run-ecs-task/waitTaskToComplete.js
+++ b/run-ecs-task/waitTaskToComplete.js
@@ -3,7 +3,7 @@ function sleep(milliseconds) {
 }
 
 async function waitTaskToComplete(ecs, cluster, taskID) {
-  let lastStatus = null
+  let task = null
 
   do {
     await sleep(1000)
@@ -13,8 +13,10 @@ async function waitTaskToComplete(ecs, cluster, taskID) {
       })
       .promise();
 
-    lastStatus = tasks[0].lastStatus
-  } while (lastStatus !== 'STOPPED')
+    task = tasks[0]
+  } while (task.lastStatus !== 'STOPPED')
+
+  return task
 }
 
 module.exports = waitTaskToComplete;


### PR DESCRIPTION
### Motivation
Prevent github action execution if ecs task exit with unsuccessful status code

### Changes
1. Extract `runEcsTask`
2. Exit from `runEcsTask` if command finishes with unsuccessful status code
3. Improve test coverage