### PR TITLE
Bump node version to 16 from deprecated 12

### DIFF
--- a/fetch-task-definition/action.yml
+++ b/fetch-task-definition/action.yml
@@ -12,5 +12,5 @@ outputs:
   filename:
     description: 'Task definition filename'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/github-ref-to-env/action.yml
+++ b/github-ref-to-env/action.yml
@@ -13,5 +13,5 @@ outputs:
     description: 'Environment name'
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/read-from-ssm-param-store/action.yml
+++ b/read-from-ssm-param-store/action.yml
@@ -12,5 +12,5 @@ outputs:
   param_json:
     description: "Parameters JSON"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/register-ecs-task-definition/action.yml
+++ b/register-ecs-task-definition/action.yml
@@ -10,5 +10,5 @@ outputs:
     description: 'The ARN of the registered ECS task definition'
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/run-ecs-task/action.yml
+++ b/run-ecs-task/action.yml
@@ -27,5 +27,5 @@ outputs:
     description: "Raw output from task"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
I don't think we need to rebuild sources, because nothing in the build process relies on the node 12 target.