### PR TITLE
Update run-ecs-task not to fail if deployments are not returned in describe services response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -12,5 +12,16 @@ A collection of GitHub actions used at Railsware
 - `yarn run_action --action name --param-1 value1 --param-2 value2 --param-3 value`
   - `name` action name to run
   - `param-x` - param like they specified in action.yml
-
+- i.e when using credential profiles it could be like following:
+```bash
+  ACTIONS_RUNNER_DEBUG=true AWS_SDK_LOAD_CONFIG=1 AWS_PROFILE=my-work-profile AWS_REGION=us-east-1 yarn run_action \
+    --action run-ecs-task \
+    --cluster my-cluster \
+    --service my-service \
+    --container my-container \
+    --command 'echo "Hello World"' \
+    --task-definition 'my_task_definition_arn' \
+    --wait-for-completion true \
+    --show-raw-output false
+```
 [Railsware](https://railsware.com)


### PR DESCRIPTION
## Motivation

Fix github action not to fail if no deployments in service response

## How to test

- [ ] Make sure there are no ongoing deployments
- [ ] Run ecs task. I.e. `ACTIONS_RUNNER_DEBUG=true AWS_SDK_LOAD_CONFIG=1 AWS_PROFILE=railsware AWS_REGION=us-east-1 yarn run_action --action run-ecs-task --cluster my-cluster --service my-service --container my-container --command 'echo "Hello World"' --task-definition 'my-task-definition-arn' --wait-for-completion true --show-raw-output false`
- [ ] Assert command does not fail