### PR TITLE
Define shared composite actions to release mailtrap SDKs

### DIFF
--- a/abort-if-tag-exists/action.yml
+++ b/abort-if-tag-exists/action.yml
@@ -21,7 +21,11 @@ runs:
         TAG: ${{ inputs.tag }}
         REPO: ${{ inputs.repo }}
       run: |
-        if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+        if output="$(gh api "repos/$REPO/git/ref/tags/$TAG" 2>&1)"; then
           echo "::error::Tag $TAG already exists"
+          exit 1
+        elif [[ "$output" != *"HTTP 404"* ]]; then
+          echo "$output" >&2
+          echo "::error::Failed to check whether tag $TAG exists in $REPO"
           exit 1
         fi

--- a/abort-if-tag-exists/action.yml
+++ b/abort-if-tag-exists/action.yml
@@ -1,0 +1,27 @@
+name: Abort if tag exists
+description: Fail the job if the given git tag already exists in the repository.
+inputs:
+  tag:
+    required: true
+    description: "Tag to check (e.g. vX.Y.Z)"
+  repo:
+    required: false
+    default: ${{ github.repository }}
+    description: "owner/name of the repository to check"
+  github-token:
+    required: false
+    default: ${{ github.token }}
+    description: "Token with read access to the repository"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        TAG: ${{ inputs.tag }}
+        REPO: ${{ inputs.repo }}
+      run: |
+        if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+          echo "::error::Tag $TAG already exists"
+          exit 1
+        fi

--- a/compute-next-semver/action.yml
+++ b/compute-next-semver/action.yml
@@ -26,7 +26,14 @@ runs:
         script: |
           const current = process.env.CURRENT;
           const bumpType = process.env.BUMP_TYPE;
-          const [major, minor, patch] = current.split('.').map(Number);
+
+          const match = current.match(/^(\d+)\.(\d+)\.(\d+)$/);
+          if (!match) {
+            core.setFailed(`Invalid current version "${current}"; expected X.Y.Z`);
+            return;
+          }
+          const [major, minor, patch] = match.slice(1).map(Number);
+
           const next = {
             major: `${major + 1}.0.0`,
             minor: `${major}.${minor + 1}.0`,

--- a/compute-next-semver/action.yml
+++ b/compute-next-semver/action.yml
@@ -1,0 +1,42 @@
+name: Compute next semver
+description: Compute the next semver and release tag from a current version and bump type.
+inputs:
+  current:
+    required: true
+    description: "Current semver version (X.Y.Z)"
+  bump-type:
+    required: true
+    description: "Semver bump type: patch | minor | major"
+outputs:
+  next:
+    description: "Next semver version (X.Y.Z)"
+    value: ${{ steps.compute.outputs.next }}
+  tag:
+    description: "Release tag (vX.Y.Z)"
+    value: ${{ steps.compute.outputs.tag }}
+runs:
+  using: composite
+  steps:
+    - id: compute
+      uses: actions/github-script@v7
+      env:
+        CURRENT: ${{ inputs.current }}
+        BUMP_TYPE: ${{ inputs.bump-type }}
+      with:
+        script: |
+          const current = process.env.CURRENT;
+          const bumpType = process.env.BUMP_TYPE;
+          const [major, minor, patch] = current.split('.').map(Number);
+          const next = {
+            major: `${major + 1}.0.0`,
+            minor: `${major}.${minor + 1}.0`,
+            patch: `${major}.${minor}.${patch + 1}`,
+          }[bumpType];
+          if (!next) {
+            core.setFailed(`Unknown bump type: ${bumpType}`);
+            return;
+          }
+
+          core.info(`Bumping ${current} -> ${next}`);
+          core.setOutput('next', next);
+          core.setOutput('tag', `v${next}`);

--- a/create-draft-github-release/action.yml
+++ b/create-draft-github-release/action.yml
@@ -1,0 +1,35 @@
+name: Create draft GitHub release
+description: Create a draft GitHub release for a tag.
+inputs:
+  tag:
+    required: true
+    description: "Release tag (vX.Y.Z)"
+  release-notes:
+    required: true
+    description: "Release notes body"
+  github-token:
+    required: false
+    default: ${{ github.token }}
+    description: "Token with permission to create releases"
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v7
+      env:
+        TAG: ${{ inputs.tag }}
+        RELEASE_NOTES: ${{ inputs.release-notes }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const tag = process.env.TAG;
+          const { data } = await github.rest.repos.createRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: tag,
+            target_commitish: 'main',
+            name: tag,
+            body: process.env.RELEASE_NOTES,
+            draft: true,
+            prerelease: false,
+          });
+          core.info(`Draft release created: ${data.html_url}`);

--- a/generate-release-notes/action.yml
+++ b/generate-release-notes/action.yml
@@ -1,0 +1,57 @@
+name: Generate release notes
+description: Generate GitHub release notes for a tag since the previous release. Outputs empty release-notes when there is nothing to release.
+inputs:
+  tag:
+    required: true
+    description: "Release tag the notes are generated for (vX.Y.Z)"
+  github-token:
+    required: false
+    default: ${{ github.token }}
+    description: "Token with read access to the repository"
+outputs:
+  release_notes:
+    description: "Generated release notes; empty when there is nothing to release"
+    value: ${{ steps.notes.outputs.release_notes }}
+runs:
+  using: composite
+  steps:
+    - id: notes
+      uses: actions/github-script@v7
+      env:
+        TAG: ${{ inputs.tag }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const tag = process.env.TAG;
+
+          // Detect the previous release tag so notes only cover PRs since then.
+          const latest = await github.rest.repos.getLatestRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          }).catch((error) => {
+            if (error.status === 404) return null;
+            throw error;
+          });
+          const previousTag = latest?.data.tag_name;
+
+          // Leave release-notes empty if nothing changed since the previous release.
+          if (previousTag) {
+            const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${previousTag}...main`,
+            });
+            if (comparison.total_commits === 0) {
+              core.info(`No commits since ${previousTag}; nothing to release. Skipping.`);
+              return;
+            }
+          }
+
+          const { data } = await github.rest.repos.generateReleaseNotes({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: tag,
+            ...(previousTag ? { previous_tag_name: previousTag } : {}),
+          });
+
+          core.setOutput('release_notes', data.body);

--- a/generate-release-notes/action.yml
+++ b/generate-release-notes/action.yml
@@ -43,6 +43,7 @@ runs:
             });
             if (comparison.total_commits === 0) {
               core.info(`No commits since ${previousTag}; nothing to release. Skipping.`);
+              core.setOutput('release_notes', '');
               return;
             }
           }

--- a/open-sdk-release-pr/action.yml
+++ b/open-sdk-release-pr/action.yml
@@ -1,0 +1,55 @@
+name: Open SDK release PR
+description: Commit the version/changelog changes to a release branch, push it, and open a release PR against main.
+inputs:
+  tag:
+    required: true
+    description: "Release tag (vX.Y.Z); the release branch is derived as release-<tag>"
+  current:
+    required: true
+    description: "Current version (X.Y.Z)"
+  next:
+    required: true
+    description: "Next version (X.Y.Z)"
+  bump-type:
+    required: true
+    description: "Semver bump type: patch | minor | major"
+  release-notes:
+    required: true
+    description: "Release notes for the PR body"
+  files:
+    required: true
+    description: "Space-separated list of files to commit"
+  github-token:
+    required: false
+    default: ${{ github.token }}
+    description: "Token with permission to push and open PRs"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        BUMP_TYPE: ${{ inputs.bump-type }}
+        CURRENT: ${{ inputs.current }}
+        NEXT: ${{ inputs.next }}
+        TAG: ${{ inputs.tag }}
+        FILES: ${{ inputs.files }}
+        RELEASE_NOTES: ${{ inputs.release-notes }}
+      run: |
+        branch="release-$TAG"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git checkout -b "$branch"
+        git add $FILES
+        git commit -m "Release $TAG"
+        git push -u origin "$branch"
+        body_file="$(mktemp)"
+        {
+          printf '## Automated `%s` bump from v%s to v%s\n\n' "$BUMP_TYPE" "$CURRENT" "$NEXT"
+          printf '%s\n' "$RELEASE_NOTES"
+        } > "$body_file"
+        gh pr create \
+          --base main \
+          --head "$branch" \
+          --title "Release $TAG" \
+          --body-file "$body_file"

--- a/open-sdk-release-pr/action.yml
+++ b/open-sdk-release-pr/action.yml
@@ -16,9 +16,6 @@ inputs:
   release-notes:
     required: true
     description: "Release notes for the PR body"
-  files:
-    required: true
-    description: "Space-separated list of files to commit"
   github-token:
     required: false
     default: ${{ github.token }}
@@ -33,15 +30,13 @@ runs:
         CURRENT: ${{ inputs.current }}
         NEXT: ${{ inputs.next }}
         TAG: ${{ inputs.tag }}
-        FILES: ${{ inputs.files }}
         RELEASE_NOTES: ${{ inputs.release-notes }}
       run: |
         branch="release-$TAG"
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git checkout -b "$branch"
-        git add $FILES
-        git commit -m "Release $TAG"
+        git commit -am "Release $TAG"
         git push -u origin "$branch"
         body_file="$(mktemp)"
         {

--- a/prepend-changelog/action.yml
+++ b/prepend-changelog/action.yml
@@ -1,0 +1,25 @@
+name: Prepend changelog entry
+description: Prepend a new "## [version] - date" section with release notes to CHANGELOG.md.
+inputs:
+  version:
+    required: true
+    description: "Version for the new changelog section (X.Y.Z)"
+  release-notes:
+    required: true
+    description: "Release notes body for the new section"
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v7
+      env:
+        VERSION: ${{ inputs.version }}
+        RELEASE_NOTES: ${{ inputs.release-notes }}
+      with:
+        script: |
+          const fs = require('fs');
+          const version = process.env.VERSION;
+          const date = new Date().toISOString().slice(0, 10);
+          const releaseNotes = process.env.RELEASE_NOTES.trim();
+          const entry = `## [${version}] - ${date}\n\n${releaseNotes}\n\n`;
+          const original = fs.readFileSync('CHANGELOG.md', 'utf8');
+          fs.writeFileSync('CHANGELOG.md', entry + original);

--- a/read-version-from-package-json/action.yml
+++ b/read-version-from-package-json/action.yml
@@ -1,0 +1,19 @@
+name: Read version from package.json
+description: Read the version and name from package.json in the working directory.
+outputs:
+  version:
+    description: "version field from package.json"
+    value: ${{ steps.read.outputs.version }}
+  package:
+    description: "name field from package.json"
+    value: ${{ steps.read.outputs.package }}
+runs:
+  using: composite
+  steps:
+    - id: read
+      shell: bash
+      run: |
+        {
+          echo "version=$(jq -r .version package.json)"
+          echo "package=$(jq -r .name package.json)"
+        } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Motivation

Define shared actions to re-use common logic in Mailtrap SDK


## Changes

- abort-if-tag-exists
- compute-next-semver
- create-draft-github-release
- generate-release-notes
- open-sdk-release-pr
- prepend-changelog
- read-version-from-package-json

## How to test

No particular QA. Tested as a part of SDK workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated release helpers to generate release notes, compute the next semantic version, create draft GitHub releases, open release PRs, and prepend changelog entries.
  * Added a utility action to read the current app version and package name from `package.json`.
  * Added a safety check to stop release workflows when a target tag already exists, and improved semver handling by validating the current version format before computing the next tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->